### PR TITLE
Add two agricultural units: decitonne per hectare, kilogram per hecto…

### DIFF
--- a/ocsm-profile.ttl
+++ b/ocsm-profile.ttl
@@ -1170,4 +1170,13 @@ ocsm:KiloGM-PER-PLANT a qudt:Unit ;
   						rdfs:label "kilogram per plant" ;
               rdfs:comment "kilogram per plant" ;
               rdfs:isDefinedBy <https://w3id.org/ocsm/> .                                           
-  
+
+ocsm:DeciTONNE-PER-HA a qudt:Unit ;
+              rdfs:label "decitonne per hectare" ;
+              rdfs:comment "decitonne per hectare" ;
+              rdfs:isDefinedBy <https://w3id.org/ocsm/> .
+
+ocsm:KiloGM-PER-HectoL a qudt:Unit ;
+              rdfs:label "kilogram per hectolitre" ;
+              rdfs:comment "kilogram per hectolitre" ;
+              rdfs:isDefinedBy <https://w3id.org/ocsm/> .


### PR DESCRIPTION
OCSM mints `ocsm:KiloGM-PER-PLANT` because QUDT has no per-plant unit. Two
further units in the same position come up in German arable reporting, and
we would like to reference them from OCSM rather than mint them privately.

**`DeciTONNE-PER-HA`** — decitonne per hectare (dt/ha) is *the* standard
yield unit in German-speaking arable farming; harvest records, advisory
reports and farm software all report in it. QUDT defines
[`DeciTONNE`](http://qudt.org/vocab/unit/DeciTONNE) and
[`KiloGM-PER-HA`](http://qudt.org/vocab/unit/KiloGM-PER-HA) but no compound
of the two, so there is currently no registered IRI for it.

**`KiloGM-PER-HectoL`** — kilogram per hectolitre is the standard expression
of *hectolitre weight* (Hektolitergewicht), a routine cereal quality
measurement recorded alongside moisture and protein. QUDT has neither the
compound nor, as far as we found, an equivalent.

Both follow QUDT's compound naming convention, as `KiloGM-PER-PLANT` does,
so they read consistently beside the units they are built from. The
declarations mirror that existing individual exactly — `a qudt:Unit` with
label, comment and `rdfs:isDefinedBy`.

Context: we are mapping German harvest documentation into OCSM and hit both
units immediately. Our implementation currently emits these IRIs in
anticipation of this proposal.